### PR TITLE
Update Baidu Netdisk to 4.17.8 and revive the package

### DIFF
--- a/com.baidu.NetDisk.metainfo.xml
+++ b/com.baidu.NetDisk.metainfo.xml
@@ -22,6 +22,7 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release date="2026-03-09" version="4.17.8" />
         <release date="2023-02-03" version="4.17.7" />
     </releases>
     <content_rating type="oars-1.1" />

--- a/com.baidu.NetDisk.yaml
+++ b/com.baidu.NetDisk.yaml
@@ -1,9 +1,9 @@
 app-id: com.baidu.NetDisk
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 separate-locales: false
 command: baidunetdisk
 finish-args:
@@ -34,12 +34,12 @@ modules:
       - type: extra-data
         filename: baidunetdisk.rpm
         only-arches: [x86_64]
-        url: https://issuepcdn.baidupcs.com/issue/netdisk/LinuxGuanjia/4.17.7/baidunetdisk_4.17.7_x86_64.rpm
-        sha256: 23244d957d33247d8e75727d2f808d95428f930019be82baa5d4e4c189fc989d
-        size: 103225050
+        url: https://pkg-ant.baidu.com/issue/netdisk/LinuxGuanjia/4.17.8/baidunetdisk_4.17.8_x86_64.rpm
+        sha256: 5db40fa5e07d1a2ef613d878989c367498f963f17f1c86a4e3918b1fb2e3ad5a
+        size: 137372337
         x-checker-data:
           type: json
-          url: https://pan.baidu.com/disk/cmsdata?app_id=250528&adCode=1&do=client
+          url: https://pan.baidu.com/disk/cmsdata?do=client
           version-query: .linux.version | capture("V(?<version>\\d+(?:\\.\\d+)+)") | .version
           url-query: .linux.url
       - type: file

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,3 @@
 {
-  "only-arches": ["x86_64"],
-  "disable-external-data-checker": true,
-  "end-of-life": "This application has not seen any update for several years, and is not compatible with non-EOL runtimes anymore."
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
- Bump runtime and base app from 23.08 to 24.08
- Update source RPM to 4.17.8 with stable pkg-ant.baidu.com URL
- Remove end-of-life flag and re-enable external data checker
- Simplify x-checker-data API URL

Fixes #56 